### PR TITLE
Updated MAHA address.

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -1681,11 +1681,11 @@
   },
   {
     "chainId": 1,
-    "address": "0xB4d930279552397bbA2ee473229f89Ec245bc365",
+    "address": "0x745407c86DF8DB893011912d3aB28e68B62E49B0",
     "name": "MahaDAO",
     "symbol": "MAHA",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13404/thumb/MAHA_Token.png?1625651604"
+    "logoURI": "https://assets.coingecko.com/coins/images/13404/large/MAHA_Token.png?1625651604"
   },
   {
     "chainId": 1,


### PR DESCRIPTION
We recently migrated the MAHA token address. This commit updates that address. PFA the official announcement regarding the change. 

Old address: 0xb4d930279552397bba2ee473229f89ec245bc365
New address: 0x745407c86df8db893011912d3ab28e68b62e49b0

https://t.me/MahadaoAnnouncements/851