### PR TITLE
fix: update mainnet JBX address

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/extended-token-list",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "description": "◦ The Uniswap extended token list",
   "main": "build/uniswap-extended.tokenlist.json",
   "scripts": {

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -5230,7 +5230,7 @@
   },
   {
     "chainId": 1,
-    "address": "0x3abF2A4f8452cCC2CF7b4C1e4663147600646f66",
+    "address": "0x4554CC10898f92D45378b98D6D6c2dD54c687Fb2",
     "name": "Juicebox",
     "symbol": "JBX",
     "decimals": 18,


### PR DESCRIPTION
$JBX, JuiceboxDAO's governance token, has been moved to a new contract for some time now. This can be confirmed on [CoinGecko](https://www.coingecko.com/en/coins/juicebox) or on the [JuiceboxDAO Blog](https://docs.juicebox.money/updates/jbx-v3-migration-guide/).