### PR TITLE
Deploy on main push

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,7 +1,9 @@
 name: Deploy
 on:
-  # manual trigger
-  workflow_dispatch:
+  push:
+    branches:
+      - main
+  workflow_dispatch: # manual trigger
 
 jobs:
   deploy:


### PR DESCRIPTION
Automates the deploy action to run on main push. Still supports optional manual trigger.